### PR TITLE
Add REST API serializer

### DIFF
--- a/api/lib/domain/VaultSummary.js
+++ b/api/lib/domain/VaultSummary.js
@@ -1,4 +1,4 @@
-class Vault {
+class VaultSummary {
 
   id;
   name;
@@ -12,6 +12,6 @@ class Vault {
 
 }
 
-module.exports = Vault;
+module.exports = VaultSummary;
 
 

--- a/api/lib/infrastructure/ioc.js
+++ b/api/lib/infrastructure/ioc.js
@@ -40,6 +40,7 @@ function build() {
   // Authenticator
   const authenticatorModel = container.register('authenticatorModel', new OAuth2ServerAuthenticatorModel({ accountRepository, encryption }));
   container.register('authenticator', new Oauth2ServerAuthenticator(authenticatorModel));
+
   return container;
 }
 

--- a/api/lib/infrastructure/routes/v1/vaults.js
+++ b/api/lib/infrastructure/routes/v1/vaults.js
@@ -1,4 +1,5 @@
 const useCases = require('../../../application');
+const vaultSerializer = require('../../serializers/vault-serializer');
 
 module.exports = function(fastify, options, done) {
 
@@ -7,8 +8,9 @@ module.exports = function(fastify, options, done) {
     url: '/vaults',
     handler: async function(request, reply) {
       const ownerId = request.user.id;
-      const vaults = await useCases.listVaults({ ownerId }, this.container);
-      return reply.code(200).send(vaults);
+      const listOfVaultSummaries = await useCases.listVaults({ ownerId }, this.container);
+      const response = vaultSerializer.serialize(listOfVaultSummaries);
+      return reply.code(200).send(response);
     },
   });
 

--- a/api/lib/infrastructure/routes/v1/vaults.js
+++ b/api/lib/infrastructure/routes/v1/vaults.js
@@ -22,7 +22,8 @@ module.exports = function(fastify, options, done) {
       const ownerId = request.user.id;
       const params = { accountId: ownerId, name: request.body.name };
       const vault = await useCases.createVault(params, this.container);
-      reply.code(201).send(vault);
+      const serialized = vaultSerializer.serialize(vault);
+      reply.code(201).send(serialized);
     },
   });
 
@@ -48,7 +49,9 @@ module.exports = function(fastify, options, done) {
       handler: async function(request, reply) {
         const ownerId = request.user.id;
         const params = { id: parseInt(request.params.id), accountId: ownerId };
-        return await useCases.getVault(params, this.container);
+        const vault = await useCases.getVault(params, this.container);
+        const serialized = vaultSerializer.serialize(vault);
+        reply.code(200).send(serialized);
       },
     });
 
@@ -58,7 +61,8 @@ module.exports = function(fastify, options, done) {
       handler: async function(request, reply) {
         const params = Object.assign({}, request.body, { id: parseInt(request.params.id) });
         const vault = await useCases.updateVault(params, this.container);
-        reply.code(200).send(vault);
+        const serialized = vaultSerializer.serialize(vault);
+        reply.code(200).send(serialized);
       },
     });
 
@@ -68,7 +72,7 @@ module.exports = function(fastify, options, done) {
       handler: async function(request, reply) {
         const params = { id: parseInt(request.params.id) };
         await useCases.deleteVault(params, this.container);
-        reply.code(204).send(null);
+        reply.code(204).send();
       },
     });
 

--- a/api/lib/infrastructure/routes/v1/vaults.js
+++ b/api/lib/infrastructure/routes/v1/vaults.js
@@ -1,5 +1,6 @@
 const useCases = require('../../../application');
 const vaultSerializer = require('../../serializers/vault-serializer');
+const itemSerializer = require('../../serializers/item-serializer');
 
 module.exports = function(fastify, options, done) {
 
@@ -8,9 +9,9 @@ module.exports = function(fastify, options, done) {
     url: '/vaults',
     handler: async function(request, reply) {
       const ownerId = request.user.id;
-      const listOfVaultSummaries = await useCases.listVaults({ ownerId }, this.container);
-      const response = vaultSerializer.serialize(listOfVaultSummaries);
-      return reply.code(200).send(response);
+      const vaultSummaryList = await useCases.listVaults({ ownerId }, this.container);
+      const serialized = vaultSerializer.serialize(vaultSummaryList);
+      return reply.code(200).send(serialized);
     },
   });
 
@@ -76,8 +77,9 @@ module.exports = function(fastify, options, done) {
       url: '/items',
       handler: async function(request, reply) {
         const params = { vaultId: parseInt(request.params.id) };
-        const items = await useCases.getVaultItems(params, this.container);
-        reply.code(200).send(items);
+        const itemList = await useCases.getVaultItems(params, this.container);
+        const serialized = itemSerializer.serialize(itemList.items);
+        reply.code(200).send(serialized);
       },
     });
 
@@ -87,7 +89,8 @@ module.exports = function(fastify, options, done) {
       handler: async function(request, reply) {
         const params = Object.assign({}, request.body, { vaultId: parseInt(request.params.id) });
         const item = await useCases.createItem(params, this.container);
-        reply.code(201).send(item);
+        const serialized = itemSerializer.serialize(item);
+        reply.code(201).send(serialized);
       },
     });
 

--- a/api/lib/infrastructure/security/oauth/authenticator/OAuth2ServerAuthenticatorModel.js
+++ b/api/lib/infrastructure/security/oauth/authenticator/OAuth2ServerAuthenticatorModel.js
@@ -119,7 +119,12 @@ class OAuth2ServerAuthenticatorModel {
 
 // https://oauth2-server.readthedocs.io/en/latest/model/spec.html#model-getaccesstoken
   async getAccessToken(accessToken) {
-    const decoded = await jwt.verify(accessToken, environment.oauth.jwtSecret);
+    let decoded;
+    try {
+       decoded = await jwt.verify(accessToken, environment.oauth.jwtSecret);
+    } catch (err) {
+      throw new InvalidTokenError('Access token expired');
+    }
 
     const isExistingAndActiveAccount = await this.#accountRepository.existsById(decoded.sub);
     if (!isExistingAndActiveAccount) {

--- a/api/lib/infrastructure/serializers/item-serializer.js
+++ b/api/lib/infrastructure/serializers/item-serializer.js
@@ -1,0 +1,43 @@
+const { InfrastructureError } = require('../errors');
+const Item = require('../../domain/Item');
+
+function serializeItem(item) {
+  return {
+    'object': 'item',
+    'id': item.id.toString(),
+    'username': item.username,
+    'password': item.password,
+    'website': item.website,
+    'created': item.createdAt.getTime(),
+    'updated': item.updatedAt.getTime(),
+    'vault_id': item.vaultId.toString(),
+  }
+}
+
+function serializeObject(object) {
+  if (object instanceof Item) {
+    return serializeItem(object);
+  }
+}
+
+function serializeArray(array) {
+  if (array[0] instanceof Item) {
+    return {
+      'object': 'list',
+      'data': array.map(serializeItem)
+    };
+  }
+}
+
+module.exports = {
+
+  serialize(data) {
+    if (!data) {
+      throw new InfrastructureError('Serialization error');
+    }
+    if (Array.isArray(data)) {
+      return serializeArray(data);
+    }
+    return serializeObject(data);
+  }
+};

--- a/api/lib/infrastructure/serializers/vault-serializer.js
+++ b/api/lib/infrastructure/serializers/vault-serializer.js
@@ -1,5 +1,17 @@
 const { InfrastructureError } = require('../errors');
+const Vault = require('../../domain/Vault');
 const VaultSummary = require('../../domain/VaultSummary');
+
+function serializeVault(vault) {
+  return {
+    'object': 'vault',
+    'id': vault.id.toString(),
+    'name': vault.name,
+    'created': vault.createdAt.getTime(),
+    'updated': vault.updatedAt.getTime(),
+    'account_id': vault.accountId.toString(),
+  }
+}
 
 function serializeVaultSummary(vaultSummary) {
   return {
@@ -11,6 +23,9 @@ function serializeVaultSummary(vaultSummary) {
 }
 
 function serializeObject(object) {
+  if (object instanceof Vault) {
+    return serializeVault(object);
+  }
   if (object instanceof VaultSummary) {
     return serializeVaultSummary(object);
   }

--- a/api/lib/infrastructure/serializers/vault-serializer.js
+++ b/api/lib/infrastructure/serializers/vault-serializer.js
@@ -1,0 +1,39 @@
+const { InfrastructureError } = require('../errors');
+const VaultSummary = require('../../domain/VaultSummary');
+
+function serializeVaultSummary(vaultSummary) {
+  return {
+    'object': 'vault_summary',
+    'id': vaultSummary.id.toString(),
+    'name': vaultSummary.name,
+    'items_count': vaultSummary.itemsCount,
+  }
+}
+
+function serializeObject(object) {
+  if (object instanceof VaultSummary) {
+    return serializeVaultSummary(object);
+  }
+}
+
+function serializeArray(array) {
+  if (array[0] instanceof VaultSummary) {
+    return {
+      'object': 'list',
+      'data': array.map(serializeVaultSummary)
+    };
+  }
+}
+
+module.exports = {
+
+  serialize(data) {
+    if (!data) {
+      throw new InfrastructureError('Serialization error');
+    }
+    if (Array.isArray(data)) {
+      return serializeArray(data);
+    }
+    return serializeObject(data);
+  }
+};

--- a/api/test/infrastructure/routes/v1/vaults_test.js
+++ b/api/test/infrastructure/routes/v1/vaults_test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const useCases = require('../../../../lib/application');
 const Item = require('../../../../lib/domain/Item');
+const ItemList = require('../../../../lib/domain/ItemList');
 const Vault = require('../../../../lib/domain/Vault');
 const VaultSummary = require('../../../../lib/domain/VaultSummary');
 const { getTestServer } = require('../../../test-helpers');
@@ -166,7 +167,7 @@ describe('infrastructure/routes/v1/vaults', () => {
 
     it('should be ok', async () => {
       // given
-      const now = new Date();
+      const now = new Date('2020-12-30');
       const item1 = new Item({
         id: 1,
         username: 'item_1',
@@ -174,6 +175,7 @@ describe('infrastructure/routes/v1/vaults', () => {
         website: 'http://website.1.url',
         createdAt: now,
         updatedAt: now,
+        vaultId: 1,
       });
       const item2 = new Item({
         id: 2,
@@ -182,9 +184,10 @@ describe('infrastructure/routes/v1/vaults', () => {
         website: 'http://website.2.url',
         createdAt: now,
         updatedAt: now,
+        vaultId: 1,
       });
-      const items = [item1, item2];
-      sinon.stub(useCases, 'getVaultItems').resolves(items);
+      const itemList = new ItemList([item1, item2]);
+      sinon.stub(useCases, 'getVaultItems').resolves(itemList);
       const routeOptions = { method: 'GET', path: '/v1/vaults/1/items' };
 
       // when
@@ -192,21 +195,28 @@ describe('infrastructure/routes/v1/vaults', () => {
 
       // then
       assert.strictEqual(response.statusCode, 200);
-      assert.deepStrictEqual(response.payload, JSON.stringify([{
-        id: 1,
-        username: 'item_1',
-        password: 'password_1',
-        website: 'http://website.1.url',
-        createdAt: now,
-        updatedAt: now,
-      }, {
-        id: 2,
-        username: 'item_2',
-        password: 'password_2',
-        website: 'http://website.2.url',
-        createdAt: now,
-        updatedAt: now,
-      }]));
+      assert.deepStrictEqual(response.json(), {
+        "object": "list",
+        "data": [{
+          "object": "item",
+          "id": "1",
+          "username": "item_1",
+          "password": "password_1",
+          "website": "http://website.1.url",
+          "created": now.getTime(),
+          "updated": now.getTime(),
+          "vault_id": "1",
+        }, {
+          "object": "item",
+          "id": "2",
+          "username": "item_2",
+          "password": "password_2",
+          "website": "http://website.2.url",
+          "created": now.getTime(),
+          "updated": now.getTime(),
+          "vault_id": "1",
+        }]
+      });
     });
   });
 
@@ -222,6 +232,7 @@ describe('infrastructure/routes/v1/vaults', () => {
         website: 'http://website.1.url',
         createdAt: now,
         updatedAt: now,
+        vaultId: 1,
       });
       sinon.stub(useCases, 'createItem').resolves(item);
       const routeOptions = { method: 'POST', path: '/v1/vaults/1/items' };
@@ -231,14 +242,16 @@ describe('infrastructure/routes/v1/vaults', () => {
 
       // then
       assert.strictEqual(response.statusCode, 201);
-      assert.deepStrictEqual(response.payload, JSON.stringify({
-        id: 1,
-        username: 'item_1',
-        password: 'password_1',
-        website: 'http://website.1.url',
-        createdAt: now,
-        updatedAt: now,
-      }));
+      assert.deepStrictEqual(response.json(), {
+        "object": "item",
+        "id": "1",
+        "username": "item_1",
+        "password": "password_1",
+        "website": "http://website.1.url",
+        "created": now.getTime(),
+        "updated": now.getTime(),
+        "vault_id": "1",
+      });
     });
   });
 

--- a/api/test/infrastructure/routes/v1/vaults_test.js
+++ b/api/test/infrastructure/routes/v1/vaults_test.js
@@ -63,12 +63,13 @@ describe('infrastructure/routes/v1/vaults', () => {
           name: 'New vault',
         }
       };
+      const now = new Date('2020-12-20');
       const createdVault = new Vault({
         id: 1,
         name: 'New vault',
         accountId: 1,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        createdAt: now,
+        updatedAt: now,
       });
       sinon.stub(useCases, 'createVault').resolves(createdVault);
 
@@ -77,7 +78,14 @@ describe('infrastructure/routes/v1/vaults', () => {
 
       // then
       assert.strictEqual(response.statusCode, 201);
-      assert.deepStrictEqual(response.payload, JSON.stringify(createdVault));
+      assert.deepStrictEqual(response.json(), {
+        "object": "vault",
+        "id": "1",
+        "name": "New vault",
+        "created": now.getTime(),
+        "updated": now.getTime(),
+        "account_id": "1",
+      });
     });
   });
 
@@ -101,14 +109,14 @@ describe('infrastructure/routes/v1/vaults', () => {
 
       // then
       assert.strictEqual(response.statusCode, 200);
-      assert.deepStrictEqual(response.payload, JSON.stringify({
-        id: 1,
-        name: 'Default vault',
-        createdAt: now,
-        updatedAt: now,
-        items: [],
-        accountId: 1,
-      }));
+      assert.deepStrictEqual(response.json(), {
+        "object": "vault",
+        "id": "1",
+        "name": "Default vault",
+        "created": now.getTime(),
+        "updated": now.getTime(),
+        "account_id": "1",
+      });
     });
   });
 
@@ -122,6 +130,7 @@ describe('infrastructure/routes/v1/vaults', () => {
         name: 'Edited vault',
         createdAt: now,
         updatedAt: now,
+        accountId: 1,
       });
       sinon.stub(useCases, 'updateVault').withArgs({ id: 1, name: 'Edited vault' }).resolves(vault);
       const routeOptions = {
@@ -137,13 +146,14 @@ describe('infrastructure/routes/v1/vaults', () => {
 
       // then
       assert.strictEqual(response.statusCode, 200);
-      assert.deepStrictEqual(response.payload, JSON.stringify({
-        id: 1,
-        name: 'Edited vault',
-        createdAt: now,
-        updatedAt: now,
-        items: [],
-      }));
+      assert.deepStrictEqual(response.json(), {
+        "object": "vault",
+        "id": "1",
+        "name": "Edited vault",
+        "created": now.getTime(),
+        "updated": now.getTime(),
+        "account_id": "1",
+      });
     });
   });
 
@@ -159,7 +169,7 @@ describe('infrastructure/routes/v1/vaults', () => {
 
       // then
       assert.strictEqual(response.statusCode, 204);
-      assert.deepStrictEqual(response.payload, JSON.stringify(null));
+      assert.deepStrictEqual(response.payload, '');
     });
   });
 

--- a/api/test/infrastructure/routes/v1/vaults_test.js
+++ b/api/test/infrastructure/routes/v1/vaults_test.js
@@ -34,15 +34,20 @@ describe('infrastructure/routes/v1/vaults', () => {
 
       // then
       assert.strictEqual(response.statusCode, 200);
-      assert.deepStrictEqual(response.payload, JSON.stringify([{
-        id: 1,
-        name: 'Default vault',
-        itemsCount: 27
-      }, {
-        id: 2,
-        name: 'Other vault',
-        itemsCount: 3
-      }]));
+      assert.deepStrictEqual(response.json(), {
+        "object": "list",
+        "data": [{
+          "object": "vault_summary",
+          "id": "1",
+          "name": "Default vault",
+          "items_count": 27,
+        }, {
+          "object": "vault_summary",
+          "id": "2",
+          "name": "Other vault",
+          "items_count": 3,
+        }]
+      });
     });
   });
 

--- a/api/test/infrastructure/serializers/item-serializer_test.js
+++ b/api/test/infrastructure/serializers/item-serializer_test.js
@@ -1,0 +1,109 @@
+const assert = require('assert');
+const itemSerializer = require('../../../lib/infrastructure/serializers/item-serializer');
+const Item = require('../../../lib/domain/Item');
+
+describe('infrastructure/serializers/item-serializer', () => {
+
+  it('should throw an error when data is `undefined` or `null`', () => {
+    try {
+      // given
+      const data = null;
+
+      // when
+      itemSerializer.serialize(data);
+
+    } catch (err) {
+      // then
+      assert.strictEqual(err.message, 'Serialization error');
+    }
+  });
+
+  describe('#serialize an Item', async () => {
+
+    it('should return a JSON object', () => {
+      // given
+      const date = new Date('2020-30-12');
+      const data = new Item({
+        id: 1,
+        username: 'username',
+        password: 'password',
+        website: 'http://web.site.url',
+        createdAt: date,
+        updatedAt: date,
+        vaultId: 1,
+      });
+      const expected = {
+        "object": "item",
+        "id": "1",
+        "username": "username",
+        "password": "password",
+        "website": "http://web.site.url",
+        "created": date.getTime(),
+        "updated": date.getTime(),
+        "vault_id": "1",
+      };
+
+      // when
+      const serialized = itemSerializer.serialize(data);
+
+      // then
+      assert.deepStrictEqual(serialized, expected);
+    });
+  });
+
+  describe('#serialize a list of Items', async () => {
+
+    it('should return a list of JSON objects', () => {
+      // given
+      const date = new Date('2020-30-12');
+      const item1 = new Item({
+        id: 1,
+        username: 'username_1',
+        password: 'password_1',
+        website: 'http://1.web.site.url',
+        createdAt: date,
+        updatedAt: date,
+        vaultId: 1,
+      });
+      const item2 = new Item({
+        id: 2,
+        username: 'username_2',
+        password: 'password_2',
+        website: 'http://2.web.site.url',
+        createdAt: date,
+        updatedAt: date,
+        vaultId: 2,
+      });
+      const data = [item1, item2];
+      const expected = {
+        "object": "list",
+        "data": [{
+          "object": "item",
+          "id": "1",
+          "username": "username_1",
+          "password": "password_1",
+          "website": "http://1.web.site.url",
+          "created": date.getTime(),
+          "updated": date.getTime(),
+          "vault_id": "1",
+        }, {
+          "object": "item",
+          "id": "2",
+          "username": "username_2",
+          "password": "password_2",
+          "website": "http://2.web.site.url",
+          "created": date.getTime(),
+          "updated": date.getTime(),
+          "vault_id": "2",
+        }]
+      };
+
+      // when
+      const serialized = itemSerializer.serialize(data);
+
+      // then
+      assert.deepStrictEqual(serialized, expected);
+    });
+  });
+
+});

--- a/api/test/infrastructure/serializers/vault-serializer_test.js
+++ b/api/test/infrastructure/serializers/vault-serializer_test.js
@@ -47,16 +47,22 @@ describe('infrastructure/serializers/vault-serializer', () => {
 
     it('should return a JSON object', () => {
       // given
-      const data = new VaultSummary({
+      const now = new Date('2020-12-30');
+      const data = new Vault({
         id: 1,
-        name: 'My vault',
-        itemsCount: 4,
+        name: 'Default',
+        createdAt: now,
+        updatedAt: now,
+        items: [],
+        accountId: 1,
       });
       const expected = {
-        "object": "vault_summary",
+        "object": "vault",
         "id": "1",
-        "name": "My vault",
-        "items_count": 4,
+        "name": "Default",
+        "created": now.getTime(),
+        "updated": now.getTime(),
+        "account_id": "1",
       };
 
       // when

--- a/api/test/infrastructure/serializers/vault-serializer_test.js
+++ b/api/test/infrastructure/serializers/vault-serializer_test.js
@@ -1,0 +1,83 @@
+const assert = require('assert');
+const vaultSerializer = require('../../../lib/infrastructure/serializers/vault-serializer');
+const VaultSummary = require('../../../lib/domain/VaultSummary');
+
+describe('infrastructure/serializers/vault-serializer', () => {
+
+  it('should throw an error when data is `undefined` or `null`', () => {
+    try {
+      // given
+      const data = null;
+
+      // when
+      vaultSerializer.serialize(data);
+
+    } catch (err) {
+      // then
+      assert.strictEqual(err.message, 'Serialization error');
+    }
+  });
+
+  describe('#serialize a VaultSummary', async () => {
+
+    it('should return a JSON object', () => {
+      // given
+      const data = new VaultSummary({
+        id: 1,
+        name: 'My vault',
+        itemsCount: 4,
+      });
+      const expected = {
+        "object": "vault_summary",
+        "id": "1",
+        "name": "My vault",
+        "items_count": 4,
+      };
+
+      // when
+      const serialized = vaultSerializer.serialize(data);
+
+      // then
+      assert.deepStrictEqual(serialized, expected);
+    });
+  });
+
+  describe('#serialize a list of VaultSummary', async () => {
+
+    it('should return a list of JSON objects', () => {
+      // given
+      const vaultSummary1 = new VaultSummary({
+        id: 1,
+        name: 'Default',
+        itemsCount: 4,
+      });
+      const vaultSummary2 = new VaultSummary({
+        id: 2,
+        name: 'Shared',
+        itemsCount: 0,
+      })
+      const data = [vaultSummary1, vaultSummary2];
+      const expected = {
+        "object": "list",
+        "data": [{
+          "object": "vault_summary",
+          "id": "1",
+          "name": "Default",
+          "items_count": 4,
+        }, {
+          "object": "vault_summary",
+          "id": "2",
+          "name": "Shared",
+          "items_count": 0,
+        }]
+      };
+
+      // when
+      const serialized = vaultSerializer.serialize(data);
+
+      // then
+      assert.deepStrictEqual(serialized, expected);
+    });
+  });
+
+});

--- a/api/test/infrastructure/serializers/vault-serializer_test.js
+++ b/api/test/infrastructure/serializers/vault-serializer_test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const vaultSerializer = require('../../../lib/infrastructure/serializers/vault-serializer');
+const Vault = require('../../../lib/domain/Vault');
 const VaultSummary = require('../../../lib/domain/VaultSummary');
 
 describe('infrastructure/serializers/vault-serializer', () => {
@@ -19,6 +20,30 @@ describe('infrastructure/serializers/vault-serializer', () => {
   });
 
   describe('#serialize a VaultSummary', async () => {
+
+    it('should return a JSON object', () => {
+      // given
+      const data = new VaultSummary({
+        id: 1,
+        name: 'My vault',
+        itemsCount: 4,
+      });
+      const expected = {
+        "object": "vault_summary",
+        "id": "1",
+        "name": "My vault",
+        "items_count": 4,
+      };
+
+      // when
+      const serialized = vaultSerializer.serialize(data);
+
+      // then
+      assert.deepStrictEqual(serialized, expected);
+    });
+  });
+
+  describe('#serialize a Vault', async () => {
 
     it('should return a JSON object', () => {
       // given

--- a/api/test/test-helpers.js
+++ b/api/test/test-helpers.js
@@ -19,10 +19,13 @@ class TestAuthenticator extends Authenticator {
   }
 }
 
-function getTestServer() {
+function getTestServer(opts = {}) {
   const container = new IocContainer();
   container.register('authenticator', new TestAuthenticator());
-  const fastify = app({ container });
+
+  const options = Object.assign({}, opts, { container });
+
+  const fastify = app(options);
   return fastify;
 }
 


### PR DESCRIPTION
- inspired by Stripe API:
  - the simplest
  - no wrapper
  - two types of results: `list` or `<object>` (ex: "item", "vault", "vault_summary")
  - Date are formatted as Integer with `Date.getTime()`
- add `infrastructure/serializers` folder with:
  - vault-serializer
  - item-serializer
- fix JWT access_token expiration (401 instead of wrong 503 error)
- use serializers in routes (application MUST returns Domain objects, not serialized data)
- associations are not serialized (maybe one day, if option is passed)