### PR TITLE
Use high-level /applications package instead of direct implementation

### DIFF
--- a/api/lib/application/commands/create-item.js
+++ b/api/lib/application/commands/create-item.js
@@ -1,6 +1,6 @@
 const Item = require('../../domain/Item');
 
-module.exports = ({ username, password, website } = {}, iocContainer) => {
+module.exports = ({ title, username, password, website } = {}, iocContainer) => {
 
   const itemRepository = iocContainer.get('itemRepository');
 

--- a/api/lib/application/queries/find-items.js
+++ b/api/lib/application/queries/find-items.js
@@ -1,6 +1,6 @@
-module.exports = (iocContainer) => {
+module.exports = ({ accountId, query }, iocContainer) => {
 
   const itemRepository = iocContainer.get('itemRepository');
 
-  return itemRepository.findAll();
+  return itemRepository.find({ accountId, query });
 }

--- a/api/lib/domain/ItemRepository.js
+++ b/api/lib/domain/ItemRepository.js
@@ -7,6 +7,11 @@ class ItemRepository {
     throw new Error('You must implement this method');
   }
 
+  find({ accountId, query }) {
+    console.log('Returns an ItemList');
+    throw new Error('You must implement this method');
+  }
+
   findById(id) {
     console.log('Returns a Item');
     throw new Error('You must implement this method');

--- a/api/lib/infrastructure/routes/v1/items.js
+++ b/api/lib/infrastructure/routes/v1/items.js
@@ -1,4 +1,5 @@
 const useCases = require('../../../application');
+const itemSerializer = require('../../serializers/item-serializer');
 
 module.exports = function(fastify, options, done) {
 
@@ -7,7 +8,8 @@ module.exports = function(fastify, options, done) {
     url: '/items',
     handler: async function(request, reply) {
       const itemList = await useCases.findItems(this.container);
-      return reply.code(200).send(itemList);
+      const serialized = itemSerializer.serialize(itemList.items);
+      return reply.code(200).send(serialized);
     },
   });
 
@@ -28,7 +30,8 @@ module.exports = function(fastify, options, done) {
       const params = request.body;
       params.id = request.params.id;
       const item = await useCases.updateItem(params, this.container);
-      return reply.code(200).send(item);
+      const serialized = itemSerializer.serialize(item);
+      return reply.code(200).send(serialized);
     },
   });
 

--- a/api/lib/infrastructure/routes/v1/items.js
+++ b/api/lib/infrastructure/routes/v1/items.js
@@ -1,6 +1,4 @@
-const findItems = require('../../../application/queries/find-items');
-const updateItem = require('../../../application/commands/update-item');
-const deleteItem = require('../../../application/commands/delete-item');
+const useCases = require('../../../application');
 
 module.exports = function(fastify, options, done) {
 
@@ -8,7 +6,7 @@ module.exports = function(fastify, options, done) {
     method: 'GET',
     url: '/items',
     handler: async function(request, reply) {
-      return findItems(this.container);
+      return useCases.findItems(this.container);
     },
   });
 
@@ -28,7 +26,7 @@ module.exports = function(fastify, options, done) {
     handler: async function(request, reply) {
       const params = request.body;
       params.id = request.params.id;
-      return updateItem(params, this.container);
+      return useCases.updateItem(params, this.container);
     },
   });
 
@@ -36,7 +34,7 @@ module.exports = function(fastify, options, done) {
     method: 'DELETE',
     url: '/items/:id',
     handler: async function(request, reply) {
-      return deleteItem({ id: request.params.id }, this.container);
+      return useCases.deleteItem({ id: request.params.id }, this.container);
     },
   });
 

--- a/api/lib/infrastructure/routes/v1/items.js
+++ b/api/lib/infrastructure/routes/v1/items.js
@@ -7,7 +7,9 @@ module.exports = function(fastify, options, done) {
     method: 'GET',
     url: '/items',
     handler: async function(request, reply) {
-      const itemList = await useCases.findItems(this.container);
+      const accountId = request.user.id;
+      const query = request.query.q;
+      const itemList = await useCases.findItems({ accountId, query }, this.container);
       const serialized = itemSerializer.serialize(itemList.items);
       return reply.code(200).send(serialized);
     },

--- a/api/lib/infrastructure/routes/v1/items.js
+++ b/api/lib/infrastructure/routes/v1/items.js
@@ -6,7 +6,8 @@ module.exports = function(fastify, options, done) {
     method: 'GET',
     url: '/items',
     handler: async function(request, reply) {
-      return useCases.findItems(this.container);
+      const itemList = await useCases.findItems(this.container);
+      return reply.code(200).send(itemList);
     },
   });
 
@@ -26,7 +27,8 @@ module.exports = function(fastify, options, done) {
     handler: async function(request, reply) {
       const params = request.body;
       params.id = request.params.id;
-      return useCases.updateItem(params, this.container);
+      const item = await useCases.updateItem(params, this.container);
+      return reply.code(200).send(item);
     },
   });
 
@@ -34,7 +36,8 @@ module.exports = function(fastify, options, done) {
     method: 'DELETE',
     url: '/items/:id',
     handler: async function(request, reply) {
-      return useCases.deleteItem({ id: request.params.id }, this.container);
+      await useCases.deleteItem({ id: request.params.id }, this.container);
+      return reply.code(204).send();
     },
   });
 

--- a/api/test/application/queries/find-items_test.js
+++ b/api/test/application/queries/find-items_test.js
@@ -9,13 +9,13 @@ describe('application/queries/find-items', () => {
     const allThePasses = Symbol('The ItemList');
     const iocContainer = new IocContainer();
     iocContainer.register('itemRepository', {
-      findAll: async function() {
+      find: async function() {
         return allThePasses;
       }
     });
 
     // when
-    const actual = await findItems(iocContainer);
+    const actual = await findItems({ accountId: 1, query: null }, iocContainer);
 
     // then
     assert.strictEqual(actual, allThePasses);

--- a/api/test/infrastructure/db_test.js
+++ b/api/test/infrastructure/db_test.js
@@ -1,5 +1,6 @@
 const environment = require('../../config/environment');
-const { Sequelize } = require('sequelize');
+const { Sequelize, Op } = require('sequelize');
+const assert = require('assert');
 
 xdescribe('db', () => {
 
@@ -14,16 +15,80 @@ xdescribe('db', () => {
   })
 
   it('should be able to access test DB', async () => {
+    try {
     // given
 
     // when
-    try {
       await sequelize.authenticate();
+
+      // then
       console.log('Connection has been established successfully.');
     } catch (error) {
       console.error('Unable to connect to the database:', error);
     }
+  });
+
+});
+
+xdescribe('Querying', () => {
+
+  const models = require('../../db/models');
+  const { Account, Vault, Item } = models;
+
+  before(async () => {
+    // Reset database
+    const queryInterface = models.sequelize.getQueryInterface();
+    await queryInterface.dropAllTables();
+
+    // Run migrations
+    await require('../../db/migrations/20201222223256-create-account').up(queryInterface, Sequelize);
+    await require('../../db/migrations/20201222225043-create-vault').up(queryInterface, Sequelize);
+    await require('../../db/migrations/20201224020123-create-item').up(queryInterface, Sequelize);
+
+    // Insert data
+    const accountA = await Account.create({ username: 'alice', encryptedPassword: 'password', email: 'alice@example.com' });
+    const vaultA = await Vault.create({ name: 'Private', accountId: accountA.id });
+    const item1 = await Item.create({ vaultId: vaultA.id, title: 'Google', username: 'alice@example.com', password: 'P@Ssw0rD', website: 'https://accounts.google.com/ServiceLogin' });
+    const item2 = await Item.create({ vaultId: vaultA.id, title: 'Twitter', username: 'alice@example.com', password: 'P@Ssw0rD', website: 'https://twitter.com/login' });
+    const item3 = await Item.create({ vaultId: vaultA.id, title: 'GitHub', username: 'alice@example.com', password: 'P@Ssw0rD', website: 'https://github.com/login' });
+
+    const accountB = await Account.create({ username: 'bob', encryptedPassword: 'password', email: 'bob@example.com' });
+    const vaultB = await Vault.create({ name: 'Private', accountId: accountB.id });
+    const item4 = await Item.create({ vaultId: vaultB.id, title: 'Google', username: 'bob@example.com', password: 'P@Ssw0rD', website: 'https://accounts.google.com/ServiceLogin' });
+    const item5 = await Item.create({ vaultId: vaultB.id, title: 'GitHub', username: 'bob@example.com', password: 'P@Ssw0rD', website: 'https://github.com/login' });
+
+  });
+
+  it('should find all items of a given user with multiple vaults', async () => {
+    // given
+    const input = '/Log';
+    const search = `%${input.trim()}%`;
+
+    // when
+    const items = await Item.findAll({
+      where: {
+        [Op.or]: [
+          { title: { [Op.iLike]: search }, },
+          { username: { [Op.iLike]: search }, },
+          { website: { [Op.iLike]: search }, },
+        ]
+      },
+      include: {
+        model: Vault,
+        attributes: [],
+        where: {
+          accountId: 1,
+        }
+      },
+      order: [
+        ['title', 'ASC']
+      ]
+    });
 
     // then
+    assert.strictEqual(items.length, 2);
+    assert.strictEqual(items[0].title, 'GitHub');
+    assert.strictEqual(items[1].title, 'Twitter');
   });
+
 });


### PR DESCRIPTION
- Fix first item creation
- Then refactor a little the items routes with explicit reply use
- Fix endpoint `GET /v1/items?[q=xxx]`
- Returns authenticated user items
- Items 
  - can be filtered by matching (case insensitive) `title`, `username`, `website`
  - are sorted by title asc.
- Use advanced and complex Sequelize querying
- Enrich skipped `db_test` that helped to understand and use Sequelize advanced features
