### PR TITLE
Use resources UUID for external needs and technical ID for internal purpose

### DIFF
--- a/api/db/migrations/20201222223256-create-account.js
+++ b/api/db/migrations/20201222223256-create-account.js
@@ -6,7 +6,13 @@ module.exports = {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+      },
+      uuid: {
+        allowNull: false,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        unique: true,
       },
       username: {
         type: Sequelize.STRING,

--- a/api/db/migrations/20201222225043-create-vault.js
+++ b/api/db/migrations/20201222225043-create-vault.js
@@ -6,7 +6,13 @@ module.exports = {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+      },
+      uuid: {
+        allowNull: false,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        unique: true,
       },
       name: {
         type: Sequelize.STRING

--- a/api/db/migrations/20201224020123-create-item.js
+++ b/api/db/migrations/20201224020123-create-item.js
@@ -6,7 +6,13 @@ module.exports = {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+      },
+      uuid: {
+        allowNull: false,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        unique: true,
       },
       type: {
         type: Sequelize.STRING,

--- a/api/db/models/account.js
+++ b/api/db/models/account.js
@@ -17,6 +17,7 @@ module.exports = (sequelize, DataTypes) => {
     }
   }
   Account.init({
+    uuid: DataTypes.UUID,
     username: DataTypes.STRING,
     encryptedPassword: DataTypes.STRING,
     email: DataTypes.STRING

--- a/api/db/models/item.js
+++ b/api/db/models/item.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => {
   }
 
   Item.init({
+    uuid: DataTypes.UUID,
     type: DataTypes.STRING,
     content: DataTypes.STRING,
   }, {

--- a/api/db/models/vault.js
+++ b/api/db/models/vault.js
@@ -23,6 +23,7 @@ module.exports = (sequelize, DataTypes) => {
   }
 
   Vault.init({
+    uuid: DataTypes.UUID,
     name: DataTypes.STRING
   }, {
     sequelize,

--- a/api/db/seeders/20201222223324-add-accounts.js
+++ b/api/db/seeders/20201222223324-add-accounts.js
@@ -1,7 +1,10 @@
+const uuidv4 = require('uuid').v4;
+
 module.exports = {
 
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     return queryInterface.bulkInsert('accounts', [{
+      uuid: uuidv4(),
       username: 'admin',
       encryptedPassword: '$2b$10$Qu.vR2Uffe3VvYTrWFirs.hZsPlmMlAX8pbWTRyM/C29K6/asAfN.',
       email: 'admin@example.net',
@@ -10,7 +13,7 @@ module.exports = {
     }]);
   },
 
-  down: async (queryInterface, Sequelize) => {
+  down: async (queryInterface) => {
     await queryInterface.dropTable('accounts');
   }
 };

--- a/api/db/seeders/20201222223324-add-accounts.js
+++ b/api/db/seeders/20201222223324-add-accounts.js
@@ -2,15 +2,6 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    /**
-     * Add seed commands here.
-     *
-     * Example:
-     * await queryInterface.bulkInsert('People', [{
-     *   name: 'John Doe',
-     *   isBetaMember: false
-     * }], {});
-    */
     return queryInterface.bulkInsert('accounts', [{
       username: 'admin',
       encryptedPassword: '$2b$10$Qu.vR2Uffe3VvYTrWFirs.hZsPlmMlAX8pbWTRyM/C29K6/asAfN.',
@@ -21,12 +12,6 @@ module.exports = {
   },
 
   down: async (queryInterface, Sequelize) => {
-    /**
-     * Add commands to revert seed here.
-     *
-     * Example:
-     * await queryInterface.bulkDelete('People', null, {});
-     */
     await queryInterface.dropTable('accounts');
   }
 };

--- a/api/db/seeders/20201222223324-add-accounts.js
+++ b/api/db/seeders/20201222223324-add-accounts.js
@@ -1,6 +1,5 @@
-'use strict';
-
 module.exports = {
+
   up: async (queryInterface, Sequelize) => {
     return queryInterface.bulkInsert('accounts', [{
       username: 'admin',

--- a/api/db/seeders/20201223143213-add-vaults.js
+++ b/api/db/seeders/20201223143213-add-vaults.js
@@ -1,17 +1,21 @@
-'use strict';
+const { Account } = require('../models');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+
+  up: async (queryInterface) => {
+
+    const account = await Account.findOne();
+
     return queryInterface.bulkInsert('vaults', [{
       name: 'Default',
       createdAt: new Date(),
       updatedAt: new Date(),
-      accountId: 1,
+      accountId: account.id,
     }, {
       name: 'Shared',
       createdAt: new Date(),
       updatedAt: new Date(),
-      accountId: 1,
+      accountId: account.id,
     }]);
   },
 

--- a/api/db/seeders/20201223143213-add-vaults.js
+++ b/api/db/seeders/20201223143213-add-vaults.js
@@ -2,15 +2,6 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    /**
-     * Add seed commands here.
-     *
-     * Example:
-     * await queryInterface.bulkInsert('People', [{
-     *   name: 'John Doe',
-     *   isBetaMember: false
-     * }], {});
-    */
     return queryInterface.bulkInsert('vaults', [{
       name: 'Default',
       createdAt: new Date(),
@@ -25,12 +16,6 @@ module.exports = {
   },
 
   down: async (queryInterface, Sequelize) => {
-    /**
-     * Add commands to revert seed here.
-     *
-     * Example:
-     * await queryInterface.bulkDelete('People', null, {});
-     */
     await queryInterface.dropTable('vaults');
   }
 };

--- a/api/db/seeders/20201223143213-add-vaults.js
+++ b/api/db/seeders/20201223143213-add-vaults.js
@@ -1,17 +1,19 @@
+const uuidv4 = require('uuid').v4;
 const { Account } = require('../models');
 
 module.exports = {
 
   up: async (queryInterface) => {
-
     const account = await Account.findOne();
 
     return queryInterface.bulkInsert('vaults', [{
+      uuid: uuidv4(),
       name: 'Default',
       createdAt: new Date(),
       updatedAt: new Date(),
       accountId: account.id,
     }, {
+      uuid: uuidv4(),
       name: 'Shared',
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -19,7 +21,7 @@ module.exports = {
     }]);
   },
 
-  down: async (queryInterface, Sequelize) => {
+  down: async (queryInterface) => {
     await queryInterface.dropTable('vaults');
   }
 };

--- a/api/db/seeders/20201224020801-add-items.js
+++ b/api/db/seeders/20201224020801-add-items.js
@@ -1,9 +1,13 @@
-'use strict';
+const { Vault } = require('../models');
 const ItemType = require('../../lib/domain/ItemType');
 const itemCypher = require('../../lib/infrastructure/ciphers/item-cipher-aes-cdc-256');
 
 module.exports = {
+
   up: async (queryInterface, Sequelize) => {
+
+    const vault = await Vault.findOne();
+
     await queryInterface.bulkInsert('items', [{
       type: ItemType.LOGIN,
       content: itemCypher.encrypt({
@@ -14,7 +18,7 @@ module.exports = {
       }),
       createdAt: new Date(),
       updatedAt: new Date(),
-      vaultId: 1,
+      vaultId: vault.id,
     }, {
       type: ItemType.LOGIN,
       content: itemCypher.encrypt({
@@ -25,7 +29,7 @@ module.exports = {
       }),
       createdAt: new Date(),
       updatedAt: new Date(),
-      vaultId: 1,
+      vaultId: vault.id,
     }, {
       type: ItemType.LOGIN,
       content: itemCypher.encrypt({
@@ -36,9 +40,8 @@ module.exports = {
       }),
       createdAt: new Date(),
       updatedAt: new Date(),
-      vaultId: 1,
+      vaultId: vault.id,
     }]);
-
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/api/db/seeders/20201224020801-add-items.js
+++ b/api/db/seeders/20201224020801-add-items.js
@@ -1,3 +1,4 @@
+const uuidv4 = require('uuid').v4;
 const { Vault } = require('../models');
 const ItemType = require('../../lib/domain/ItemType');
 const itemCypher = require('../../lib/infrastructure/ciphers/item-cipher-aes-cdc-256');
@@ -9,6 +10,7 @@ module.exports = {
     const vault = await Vault.findOne();
 
     await queryInterface.bulkInsert('items', [{
+      uuid: uuidv4(),
       type: ItemType.LOGIN,
       content: itemCypher.encrypt({
         title: 'Item 1',
@@ -20,6 +22,7 @@ module.exports = {
       updatedAt: new Date(),
       vaultId: vault.id,
     }, {
+      uuid: uuidv4(),
       type: ItemType.LOGIN,
       content: itemCypher.encrypt({
         title: 'Item 2',
@@ -31,6 +34,7 @@ module.exports = {
       updatedAt: new Date(),
       vaultId: vault.id,
     }, {
+      uuid: uuidv4(),
       type: ItemType.LOGIN,
       content: itemCypher.encrypt({
         title: 'Item 3',
@@ -44,7 +48,7 @@ module.exports = {
     }]);
   },
 
-  down: async (queryInterface, Sequelize) => {
+  down: async (queryInterface) => {
     await queryInterface.dropTable('items');
   }
 };

--- a/api/lib/application/commands/create-account.js
+++ b/api/lib/application/commands/create-account.js
@@ -32,7 +32,7 @@ module.exports = async ({ username, password, email } = {}, iocContainer) => {
 
   await vaultRepository.save(new Vault({
     name: 'Private',
-    accountId: account.id,
+    accountUuid: account.uuid,
   }));
 
   return account;

--- a/api/lib/application/commands/create-item.js
+++ b/api/lib/application/commands/create-item.js
@@ -1,13 +1,14 @@
+const uuidv4 = require('uuid').v4;
 const Item = require('../../domain/Item');
 const ItemType = require('../../domain/ItemType');
 
-module.exports = ({ title, username, password, website } = {}, iocContainer) => {
+module.exports = ({ vaultUuid, title, username, password, website } = {}, iocContainer) => {
 
   const itemRepository = iocContainer.get('itemRepository');
 
   const now = new Date();
 
-  const item = new Item({ type: ItemType.LOGIN, title, username, password, website, createdAt: now, updatedAt: now, vaultId: 1 });
+  const item = new Item({ uuid: uuidv4(), type: ItemType.LOGIN, title, username, password, website, createdAt: now, updatedAt: now, vaultUuid });
 
   return itemRepository.save(item);
 }

--- a/api/lib/application/commands/create-vault.js
+++ b/api/lib/application/commands/create-vault.js
@@ -1,12 +1,16 @@
+const uuidv4 = require('uuid').v4;
 const Vault = require('../../domain/Vault');
 
 module.exports = async ({ accountId, name } = {}, iocContainer) => {
+
+  const accountRepository = iocContainer.get('accountRepository');
+  const account = await accountRepository.findById(accountId);
 
   const vaultRepository = iocContainer.get('vaultRepository');
 
   const now = new Date();
 
-  const vault = new Vault({ name, createdAt: now, updatedAt: now, accountId });
+  const vault = new Vault({ uuid: uuidv4(), name, createdAt: now, updatedAt: now, accountUuid: account.uuid });
 
   return await vaultRepository.save(vault);
 }

--- a/api/lib/application/commands/delete-item.js
+++ b/api/lib/application/commands/delete-item.js
@@ -1,6 +1,6 @@
-module.exports = ({ id }, iocContainer) => {
+module.exports = ({ uuid }, iocContainer) => {
 
   const itemRepository = iocContainer.get('itemRepository');
 
-  return itemRepository.delete(id);
+  return itemRepository.deleteByUuid(uuid);
 }

--- a/api/lib/application/commands/delete-vault.js
+++ b/api/lib/application/commands/delete-vault.js
@@ -1,6 +1,6 @@
-module.exports = ({ id }, iocContainer) => {
+module.exports = ({ uuid }, iocContainer) => {
 
   const vaultRepository = iocContainer.get('vaultRepository');
 
-  return vaultRepository.delete(id);
+  return vaultRepository.deleteByUuid(uuid);
 }

--- a/api/lib/application/commands/update-item.js
+++ b/api/lib/application/commands/update-item.js
@@ -1,8 +1,8 @@
-module.exports = async ({ id, username, password, website } = {}, iocContainer) => {
+module.exports = async ({ uuid, username, password, website } = {}, iocContainer) => {
 
   const itemRepository = iocContainer.get('itemRepository');
 
-  const transientItem = await itemRepository.findById(id);
+  const transientItem = await itemRepository.findByUud(uuid);
 
   if (title) {
     transientItem.title = title;

--- a/api/lib/application/commands/update-vault.js
+++ b/api/lib/application/commands/update-vault.js
@@ -1,8 +1,8 @@
-module.exports = async ({ id, name } = {}, iocContainer) => {
+module.exports = async ({ uuid, name } = {}, iocContainer) => {
 
   const vaultRepository = iocContainer.get('vaultRepository');
 
-  const transientVault = await vaultRepository.findById(id);
+  const transientVault = await vaultRepository.findByUuid(uuid);
 
   if (name) {
     transientVault.name = name;

--- a/api/lib/application/queries/find-items.js
+++ b/api/lib/application/queries/find-items.js
@@ -1,6 +1,6 @@
-module.exports = ({ accountId, query }, iocContainer) => {
+module.exports = ({ accountId }, iocContainer) => {
 
   const itemRepository = iocContainer.get('itemRepository');
 
-  return itemRepository.find({ accountId, query });
+  return itemRepository.find({ accountId });
 }

--- a/api/lib/application/queries/get-vault-items.js
+++ b/api/lib/application/queries/get-vault-items.js
@@ -1,6 +1,6 @@
-module.exports = ({ vaultId }, iocContainer) => {
+module.exports = ({ vaultUuid }, iocContainer) => {
 
   const itemRepository = iocContainer.get('itemRepository');
 
-  return itemRepository.findAllByVaultId(vaultId);
+  return itemRepository.findAllByVaultUuid(vaultUuid);
 }

--- a/api/lib/application/queries/get-vault.js
+++ b/api/lib/application/queries/get-vault.js
@@ -1,6 +1,6 @@
-module.exports = ({ id, accountId }, iocContainer) => {
+module.exports = ({ vaultUuid, accountId }, iocContainer) => {
 
   const vaultRepository = iocContainer.get('vaultRepository');
 
-  return vaultRepository.getByIdAndAccountId(id, accountId);
+  return vaultRepository.getByUuidAndAccountId(id, accountId);
 }

--- a/api/lib/domain/Account.js
+++ b/api/lib/domain/Account.js
@@ -1,6 +1,7 @@
 class Account {
 
   id;
+  uuid;
   username;
   email;
   createdAt;
@@ -8,6 +9,7 @@ class Account {
 
   constructor(attributes = {}) {
     this.id = attributes.id;
+    this.uuid = attributes.uuid;
     this.username = attributes.username;
     this.email = attributes.email;
     this.createdAt = attributes.createdAt;

--- a/api/lib/domain/AccountRepository.js
+++ b/api/lib/domain/AccountRepository.js
@@ -1,12 +1,17 @@
 class AccountRepository {
 
   save(account) {
-    console.log('Returns a Account');
+    console.log('Returns an Account');
     throw new Error('You must implement this method');
   }
 
   findById(id) {
-    console.log('Returns a Account');
+    console.log('Returns an Account');
+    throw new Error('You must implement this method');
+  }
+
+  findByUuid(uuid) {
+    console.log('Returns an Account');
     throw new Error('You must implement this method');
   }
 
@@ -20,7 +25,17 @@ class AccountRepository {
     throw new Error('You must implement this method');
   }
 
+  deleteByUuid(uuid) {
+    console.log('Returns nothing');
+    throw new Error('You must implement this method');
+  }
+
   existsById(id) {
+    console.log('Returns a boolean');
+    throw new Error('You must implement this method');
+  }
+
+  existsByUuid(uuid) {
     console.log('Returns a boolean');
     throw new Error('You must implement this method');
   }

--- a/api/lib/domain/Item.js
+++ b/api/lib/domain/Item.js
@@ -1,6 +1,7 @@
 class Item {
 
   id;
+  uuid;
   type;
   title;
   username;
@@ -12,6 +13,7 @@ class Item {
 
   constructor(attributes = {}) {
     this.id = attributes.id;
+    this.uuid = attributes.uuid;
     this.type = attributes.type;
     this.createdAt = attributes.createdAt;
     this.updatedAt = attributes.updatedAt;

--- a/api/lib/domain/Item.js
+++ b/api/lib/domain/Item.js
@@ -9,7 +9,7 @@ class Item {
   website;
   createdAt;
   updatedAt;
-  vaultId; // as VaultID, for a business and critic reference information, not like a technical ID
+  vaultUuid; // as VaultID, for a business and critic reference information, not like a technical ID
 
   constructor(attributes = {}) {
     this.id = attributes.id;
@@ -17,7 +17,7 @@ class Item {
     this.type = attributes.type;
     this.createdAt = attributes.createdAt;
     this.updatedAt = attributes.updatedAt;
-    this.vaultId = attributes.vaultId;
+    this.vaultUuid = attributes.vaultUuid;
     this.content = attributes;
   }
 

--- a/api/lib/domain/ItemRepository.js
+++ b/api/lib/domain/ItemRepository.js
@@ -3,7 +3,7 @@
 class ItemRepository {
 
   save(item) {
-    console.log('Returns a Item');
+    console.log('Returns an Item');
     throw new Error('You must implement this method');
   }
 
@@ -13,7 +13,12 @@ class ItemRepository {
   }
 
   findById(id) {
-    console.log('Returns a Item');
+    console.log('Returns an Item');
+    throw new Error('You must implement this method');
+  }
+
+  findByUuid(uuid) {
+    console.log('Returns an Item');
     throw new Error('You must implement this method');
   }
 
@@ -27,11 +32,20 @@ class ItemRepository {
     throw new Error('You must implement this method');
   }
 
+  deleteByUuid(uuid) {
+    console.log('Returns nothing');
+    throw new Error('You must implement this method');
+  }
+
   existsById(id) {
     console.log('Returns a boolean');
     throw new Error('You must implement this method');
   }
 
+  existsByUuid(uuid) {
+    console.log('Returns a boolean');
+    throw new Error('You must implement this method');
+  }
 }
 
 module.exports = ItemRepository;

--- a/api/lib/domain/ItemRepository.js
+++ b/api/lib/domain/ItemRepository.js
@@ -7,7 +7,7 @@ class ItemRepository {
     throw new Error('You must implement this method');
   }
 
-  find({ accountId, query }) {
+  find({ accountId }) {
     console.log('Returns an ItemList');
     throw new Error('You must implement this method');
   }
@@ -22,7 +22,7 @@ class ItemRepository {
     throw new Error('You must implement this method');
   }
 
-  findAllByVaultId(vaultId) {
+  findAllByVaultUuid(vaultUuid) {
     console.log('Returns a ItemList');
     throw new Error('You must implement this method');
   }

--- a/api/lib/domain/Vault.js
+++ b/api/lib/domain/Vault.js
@@ -6,7 +6,7 @@ class Vault {
   createdAt;
   updatedAt;
   items;
-  accountId;
+  accountUuid;
 
   constructor(attributes = {}) {
     this.id = attributes.id;
@@ -15,7 +15,7 @@ class Vault {
     this.createdAt = attributes.createdAt || new Date();
     this.updatedAt = attributes.updatedAt || new Date();
     this.items = attributes.items || [];
-    this.accountId = attributes.accountId;
+    this.accountUuid = attributes.accountUuid;
   }
 
 }

--- a/api/lib/domain/Vault.js
+++ b/api/lib/domain/Vault.js
@@ -1,6 +1,7 @@
 class Vault {
 
   id;
+  uuid;
   name;
   createdAt;
   updatedAt;
@@ -9,6 +10,7 @@ class Vault {
 
   constructor(attributes = {}) {
     this.id = attributes.id;
+    this.uuid = attributes.uuid;
     this.name = attributes.name;
     this.createdAt = attributes.createdAt || new Date();
     this.updatedAt = attributes.updatedAt || new Date();

--- a/api/lib/domain/VaultRepository.js
+++ b/api/lib/domain/VaultRepository.js
@@ -5,7 +5,7 @@ class VaultRepository {
     throw new Error('You must implement this method');
   }
 
-  getByIdAndAccountId(id, accountId) {
+  getByUuidAndAccountId(id, accountId) {
     console.log('Returns a Vault');
     throw new Error('You must implement this method');
   }

--- a/api/lib/domain/VaultRepository.js
+++ b/api/lib/domain/VaultRepository.js
@@ -15,12 +15,27 @@ class VaultRepository {
     throw new Error('You must implement this method');
   }
 
+  findByUuid(uuid) {
+    console.log('Returns a Vault');
+    throw new Error('You must implement this method');
+  }
+
   delete(id) {
     console.log('Returns nothing');
     throw new Error('You must implement this method');
   }
 
+  deleteByUuid(uuid) {
+    console.log('Returns nothing');
+    throw new Error('You must implement this method');
+  }
+
   existsById(id) {
+    console.log('Returns a boolean');
+    throw new Error('You must implement this method');
+  }
+
+  existsByUuid(uuid) {
     console.log('Returns a boolean');
     throw new Error('You must implement this method');
   }

--- a/api/lib/domain/VaultSummary.js
+++ b/api/lib/domain/VaultSummary.js
@@ -7,7 +7,7 @@ class VaultSummary {
 
   constructor(attributes = {}) {
     this.id = attributes.id;
-    this.uuid = attributes.id;
+    this.uuid = attributes.uuid;
     this.name = attributes.name;
     this.itemsCount = attributes.itemsCount;
   }

--- a/api/lib/domain/VaultSummary.js
+++ b/api/lib/domain/VaultSummary.js
@@ -1,11 +1,13 @@
 class VaultSummary {
 
   id;
+  uuid;
   name;
   itemsCount;
 
   constructor(attributes = {}) {
     this.id = attributes.id;
+    this.uuid = attributes.id;
     this.name = attributes.name;
     this.itemsCount = attributes.itemsCount;
   }

--- a/api/lib/infrastructure/repositories/VaultRepositorySql.js
+++ b/api/lib/infrastructure/repositories/VaultRepositorySql.js
@@ -8,7 +8,7 @@ const { QueryTypes } = require('sequelize');
 class VaultRepositorySql extends VaultRepository {
 
   async save(vault) {
-    const accountModel = await models.Account.findOne({ where: { uuid: item.accountUuid }});
+    const accountModel = await models.Account.findOne({ where: { uuid: vault.accountUuid }});
 
     let persistedModel;
     if (vault.id) {
@@ -18,7 +18,13 @@ class VaultRepositorySql extends VaultRepository {
       persistedModel.accountId = accountModel.id;
       await persistedModel.save();
     } else {
-      persistedModel = await this.Model.create(vault);
+      persistedModel = await this.Model.create({
+        uuid: vault.uuid,
+        name: vault.name,
+        createdAt: vault.createdAt,
+        updatedAt: vault.updatedAt,
+        accountId: accountModel.id
+      });
     }
     return new Vault(persistedModel);
   }
@@ -36,15 +42,15 @@ WHERE "accountId"=${accountId}
     return data.map(rowModel => new VaultSummary(rowModel));
   }
 
-  async getByIdAndAccountId(id, accountId) {
-    const model = await this.Model.findOne({ where: { id, accountId } });
+  async getByUuidAndAccountId(uuid, accountId) {
+    const model = await this.Model.findOne({ where: { uuid, accountId } });
     if (model) {
       return new Vault(model);
     }
   }
 
-  async existsByIdAndAccountId(id, accountId) {
-    const results = await models.sequelize.query(`SELECT 1 FROM ${this.tableName} where id=${id} and "accountId"=${accountId}`, { type: QueryTypes.SELECT });
+  async existsByUuidAndAccountId(uuid, accountId) {
+    const results = await models.sequelize.query(`SELECT 1 FROM ${this.tableName} where uuid='${uuid}' and "accountId"=${accountId}`, { type: QueryTypes.SELECT });
     return results.length > 0;
   }
 }

--- a/api/lib/infrastructure/repositories/VaultRepositorySql.js
+++ b/api/lib/infrastructure/repositories/VaultRepositorySql.js
@@ -8,12 +8,14 @@ const { QueryTypes } = require('sequelize');
 class VaultRepositorySql extends VaultRepository {
 
   async save(vault) {
+    const accountModel = await models.Account.findOne({ where: { uuid: item.accountUuid }});
+
     let persistedModel;
     if (vault.id) {
       persistedModel = await this.Model.findByPk(vault.id);
       persistedModel.name = vault.name;
       persistedModel.updatedAt = vault.updatedAt;
-      persistedModel.accountId = vault.accountId;
+      persistedModel.accountId = accountModel.id;
       await persistedModel.save();
     } else {
       persistedModel = await this.Model.create(vault);

--- a/api/lib/infrastructure/repositories/sql-repository-factory.js
+++ b/api/lib/infrastructure/repositories/sql-repository-factory.js
@@ -33,7 +33,7 @@ function build({ Entity, Repository, tableName, modelName } = {}) {
   }
 
   Repository.prototype.existsByUuid = async (uuid) => {
-    const results = await models.sequelize.query(`SELECT 1 FROM ${tableName} where uuid=${uuid}`, { type: QueryTypes.SELECT });
+    const results = await models.sequelize.query(`SELECT 1 FROM ${tableName} where uuid='${uuid}'`, { type: QueryTypes.SELECT });
     return results.length > 0;
   }
 

--- a/api/lib/infrastructure/repositories/sql-repository-factory.js
+++ b/api/lib/infrastructure/repositories/sql-repository-factory.js
@@ -20,13 +20,29 @@ function build({ Entity, Repository, tableName, modelName } = {}) {
     }
   }
 
+  Repository.prototype.findByUuid = async (uuid) => {
+    const model = await Model.findOne({ where: { uuid }});
+    if (model) {
+      return new Entity(model);
+    }
+  }
+
   Repository.prototype.existsById = async (id) => {
     const results = await models.sequelize.query(`SELECT 1 FROM ${tableName} where id=${id}`, { type: QueryTypes.SELECT });
     return results.length > 0;
   }
 
+  Repository.prototype.existsByUuid = async (uuid) => {
+    const results = await models.sequelize.query(`SELECT 1 FROM ${tableName} where uuid=${uuid}`, { type: QueryTypes.SELECT });
+    return results.length > 0;
+  }
+
   Repository.prototype.delete = async (id) => {
     return await Model.destroy({ where: { id } });
+  }
+
+  Repository.prototype.deleteByUuid = async (uuid) => {
+    return await Model.destroy({ where: { uuid } });
   }
 
   return Repository;

--- a/api/lib/infrastructure/routes/v1/items.js
+++ b/api/lib/infrastructure/routes/v1/items.js
@@ -17,7 +17,7 @@ module.exports = function(fastify, options, done) {
 
   fastify.route({
     method: 'GET',
-    url: '/items/:id',
+    url: '/items/:uuid',
     handler: async function(request, reply) {
       // TODO
       this.log.info('Retrieves the details of an existing item.');
@@ -27,10 +27,10 @@ module.exports = function(fastify, options, done) {
 
   fastify.route({
     method: 'PATCH',
-    url: '/items/:id',
+    url: '/items/:uuid',
     handler: async function(request, reply) {
       const params = request.body;
-      params.id = request.params.id;
+      params.uuid = request.params.uuid;
       const item = await useCases.updateItem(params, this.container);
       const serialized = itemSerializer.serialize(item);
       return reply.code(200).send(serialized);

--- a/api/lib/infrastructure/routes/v1/vaults.js
+++ b/api/lib/infrastructure/routes/v1/vaults.js
@@ -30,10 +30,10 @@ module.exports = function(fastify, options, done) {
   fastify.register((instance, opts, done) => {
 
     instance.addHook('preValidation', async (request, reply) => {
-      const vaultId = parseInt(request.params.id);
+      const vaultUuid = request.params.uuid;
       const ownerId = request.user.id;
       const vaultRepository = fastify.container.get('vaultRepository');
-      const isExisting = await vaultRepository.existsByIdAndAccountId(vaultId, ownerId);
+      const isExisting = await vaultRepository.existsByUuidAndAccountId(vaultUuid, ownerId);
       if (!isExisting) {
         reply.code(404).send({
           "statusCode": 404,
@@ -48,7 +48,7 @@ module.exports = function(fastify, options, done) {
       url: '/',
       handler: async function(request, reply) {
         const ownerId = request.user.id;
-        const params = { id: parseInt(request.params.id), accountId: ownerId };
+        const params = { vaultUuid: request.params.uuid, accountId: ownerId };
         const vault = await useCases.getVault(params, this.container);
         const serialized = vaultSerializer.serialize(vault);
         reply.code(200).send(serialized);
@@ -59,7 +59,7 @@ module.exports = function(fastify, options, done) {
       method: 'PATCH',
       url: '/',
       handler: async function(request, reply) {
-        const params = Object.assign({}, request.body, { id: parseInt(request.params.id) });
+        const params = Object.assign({}, request.body, { uuid: request.params.uuid });
         const vault = await useCases.updateVault(params, this.container);
         const serialized = vaultSerializer.serialize(vault);
         reply.code(200).send(serialized);
@@ -70,7 +70,7 @@ module.exports = function(fastify, options, done) {
       method: 'DELETE',
       url: '/',
       handler: async function(request, reply) {
-        const params = { id: parseInt(request.params.id) };
+        const params = { uuid: request.params.uuid };
         await useCases.deleteVault(params, this.container);
         reply.code(204).send();
       },
@@ -80,7 +80,7 @@ module.exports = function(fastify, options, done) {
       method: 'GET',
       url: '/items',
       handler: async function(request, reply) {
-        const params = { vaultId: parseInt(request.params.id) };
+        const params = { vaultUuid: request.params.uuid };
         const itemList = await useCases.getVaultItems(params, this.container);
         const serialized = itemSerializer.serialize(itemList.items);
         reply.code(200).send(serialized);
@@ -91,7 +91,7 @@ module.exports = function(fastify, options, done) {
       method: 'POST',
       url: '/items',
       handler: async function(request, reply) {
-        const params = Object.assign({}, request.body, { vaultId: parseInt(request.params.id) });
+        const params = Object.assign({}, request.body, { vaultUuid: request.params.uuid });
         const item = await useCases.createItem(params, this.container);
         const serialized = itemSerializer.serialize(item);
         reply.code(201).send(serialized);
@@ -99,7 +99,7 @@ module.exports = function(fastify, options, done) {
     });
 
     done();
-  }, { prefix: '/vaults/:id' });
+  }, { prefix: '/vaults/:uuid' });
 
   done();
 };

--- a/api/lib/infrastructure/serializers/item-serializer.js
+++ b/api/lib/infrastructure/serializers/item-serializer.js
@@ -4,7 +4,7 @@ const Item = require('../../domain/Item');
 function serializeItem(item) {
   return {
     'object': 'item',
-    'id': item.id.toString(),
+    'id': item.uuid,
     'type': item.type,
     'title': item.title,
     'username': item.username,
@@ -12,7 +12,7 @@ function serializeItem(item) {
     'website': item.website,
     'created': item.createdAt.getTime(),
     'updated': item.updatedAt.getTime(),
-    'vault_id': item.vaultId.toString(),
+    'vault_id': item.vaultUuid,
   }
 }
 

--- a/api/lib/infrastructure/serializers/vault-serializer.js
+++ b/api/lib/infrastructure/serializers/vault-serializer.js
@@ -5,18 +5,18 @@ const VaultSummary = require('../../domain/VaultSummary');
 function serializeVault(vault) {
   return {
     'object': 'vault',
-    'id': vault.id.toString(),
+    'id': vault.uuid,
     'name': vault.name,
     'created': vault.createdAt.getTime(),
     'updated': vault.updatedAt.getTime(),
-    'account_id': vault.accountId.toString(),
+    'account_id': vault.accountUuid,
   }
 }
 
 function serializeVaultSummary(vaultSummary) {
   return {
     'object': 'vault_summary',
-    'id': vaultSummary.id.toString(),
+    'id': vaultSummary.uuid,
     'name': vaultSummary.name,
     'items_count': vaultSummary.itemsCount,
   }

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "description": "Simple collaborative password manager in Node.js",
   "main": "index.js",
   "scripts": {
-    "db:reset": "node db/scripts/reset.js && npm run db:migrate && npm run db:seed",
+      "db:reset": "node db/scripts/reset.js && npm run db:migrate && npm run db:seed",
     "db:migrate": "sequelize db:migrate",
     "db:seed": "sequelize db:seed:all",
     "prestart": "npm run db:migrate",

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,8 @@
     "oauth2-server": "^3.1.1",
     "pg": "^8.5.1",
     "sequelize": "^6.3.5",
-    "sequelize-cli": "^6.2.0"
+    "sequelize-cli": "^6.2.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "description": "Simple collaborative password manager in Node.js",
   "main": "index.js",
   "scripts": {
-      "db:reset": "node db/scripts/reset.js && npm run db:migrate && npm run db:seed",
+    "db:reset": "node db/scripts/reset.js && npm run db:migrate && npm run db:seed",
     "db:migrate": "sequelize db:migrate",
     "db:seed": "sequelize db:seed:all",
     "prestart": "npm run db:migrate",

--- a/api/test/application/commands/delete-item_test.js
+++ b/api/test/application/commands/delete-item_test.js
@@ -9,14 +9,14 @@ describe('application/commands/delete-item', () => {
     const deleteStub = sinon.stub();
     const iocContainer = new IocContainer();
     iocContainer.register('itemRepository', {
-      delete: deleteStub
+      deleteByUuid: deleteStub
     });
-    const itemId = 1234;
+    const itemUuid = '5977cae0-8f54-4927-b054-7eb6e3cccd2d';
 
     // when
-    await deleteItem({ id: itemId}, iocContainer);
+    await deleteItem({ uuid: itemUuid}, iocContainer);
 
     // then
-    sinon.assert.calledWithExactly(deleteStub, itemId);
+    sinon.assert.calledWithExactly(deleteStub, itemUuid);
   });
 });

--- a/api/test/infrastructure/routes/v1/vaults_test.js
+++ b/api/test/infrastructure/routes/v1/vaults_test.js
@@ -24,8 +24,8 @@ describe('infrastructure/routes/v1/vaults', () => {
 
     it('should be ok', async () => {
       // given
-      const vault1 = new VaultSummary({ id: 1, name: 'Default vault', itemsCount: 27 });
-      const vault2 = new VaultSummary({ id: 2, name: 'Other vault', itemsCount: 3 });
+      const vault1 = new VaultSummary({ id: 1, uuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13', name: 'Default vault', itemsCount: 27 });
+      const vault2 = new VaultSummary({ id: 2, uuid: '50cb9513-6b10-4dce-a64d-d0778d10958d', name: 'Other vault', itemsCount: 3 });
       const vaults = [vault1, vault2];
       sinon.stub(useCases, 'listVaults').withArgs({ ownerId: 1 }).resolves(vaults);
       const routeOptions = { method: 'GET', path: '/v1/vaults' };
@@ -39,12 +39,12 @@ describe('infrastructure/routes/v1/vaults', () => {
         "object": "list",
         "data": [{
           "object": "vault_summary",
-          "id": "1",
+          "id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
           "name": "Default vault",
           "items_count": 27,
         }, {
           "object": "vault_summary",
-          "id": "2",
+          "id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
           "name": "Other vault",
           "items_count": 3,
         }]
@@ -66,8 +66,9 @@ describe('infrastructure/routes/v1/vaults', () => {
       const now = new Date('2020-12-20');
       const createdVault = new Vault({
         id: 1,
+        uuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
         name: 'New vault',
-        accountId: 1,
+        accountUuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4',
         createdAt: now,
         updatedAt: now,
       });
@@ -80,11 +81,11 @@ describe('infrastructure/routes/v1/vaults', () => {
       assert.strictEqual(response.statusCode, 201);
       assert.deepStrictEqual(response.json(), {
         "object": "vault",
-        "id": "1",
+        "id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
         "name": "New vault",
         "created": now.getTime(),
         "updated": now.getTime(),
-        "account_id": "1",
+        "account_id": "f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4",
       });
     });
   });
@@ -96,8 +97,9 @@ describe('infrastructure/routes/v1/vaults', () => {
       const now = new Date();
       const vault = new Vault({
         id: 1,
+        uuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4',
         name: 'Default vault',
-        accountId: 1,
+        accountUuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
         createdAt: now,
         updatedAt: now,
       });
@@ -111,11 +113,11 @@ describe('infrastructure/routes/v1/vaults', () => {
       assert.strictEqual(response.statusCode, 200);
       assert.deepStrictEqual(response.json(), {
         "object": "vault",
-        "id": "1",
+        "id": "f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4",
         "name": "Default vault",
         "created": now.getTime(),
         "updated": now.getTime(),
-        "account_id": "1",
+        "account_id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
       });
     });
   });
@@ -127,10 +129,11 @@ describe('infrastructure/routes/v1/vaults', () => {
       const now = new Date();
       const vault = new Vault({
         id: 1,
+        uuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
         name: 'Edited vault',
         createdAt: now,
         updatedAt: now,
-        accountId: 1,
+        accountUuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
       });
       sinon.stub(useCases, 'updateVault').withArgs({ id: 1, name: 'Edited vault' }).resolves(vault);
       const routeOptions = {
@@ -148,11 +151,11 @@ describe('infrastructure/routes/v1/vaults', () => {
       assert.strictEqual(response.statusCode, 200);
       assert.deepStrictEqual(response.json(), {
         "object": "vault",
-        "id": "1",
+        "id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
         "name": "Edited vault",
         "created": now.getTime(),
         "updated": now.getTime(),
-        "account_id": "1",
+        "account_id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
       });
     });
   });
@@ -180,25 +183,27 @@ describe('infrastructure/routes/v1/vaults', () => {
       const now = new Date('2020-12-30');
       const item1 = new Item({
         id: 1,
+        uuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4',
         username: 'item_1',
         password: 'password_1',
         website: 'http://website.1.url',
         createdAt: now,
         updatedAt: now,
-        vaultId: 1,
+        vaultUuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
       });
       const item2 = new Item({
         id: 2,
+        uuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
         username: 'item_2',
         password: 'password_2',
         website: 'http://website.2.url',
         createdAt: now,
         updatedAt: now,
-        vaultId: 1,
+        vaultUuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
       });
       const itemList = new ItemList([item1, item2]);
       sinon.stub(useCases, 'getVaultItems').resolves(itemList);
-      const routeOptions = { method: 'GET', path: '/v1/vaults/1/items' };
+      const routeOptions = { method: 'GET', path: '/v1/vaults/3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13/items' };
 
       // when
       const response = await testServer.inject(routeOptions);
@@ -209,43 +214,44 @@ describe('infrastructure/routes/v1/vaults', () => {
         "object": "list",
         "data": [{
           "object": "item",
-          "id": "1",
+          "id": "f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4",
           "username": "item_1",
           "password": "password_1",
           "website": "http://website.1.url",
           "created": now.getTime(),
           "updated": now.getTime(),
-          "vault_id": "1",
+          "vault_id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
         }, {
           "object": "item",
-          "id": "2",
+          "id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
           "username": "item_2",
           "password": "password_2",
           "website": "http://website.2.url",
           "created": now.getTime(),
           "updated": now.getTime(),
-          "vault_id": "1",
+          "vault_id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
         }]
       });
     });
   });
 
-  describe('POST /vaults/:id/items', async () => {
+  describe('POST /vaults/:uuid/items', async () => {
 
     it('should be ok', async () => {
       // given
       const now = new Date();
       const item = new Item({
         id: 1,
+        uuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4',
         username: 'item_1',
         password: 'password_1',
         website: 'http://website.1.url',
         createdAt: now,
         updatedAt: now,
-        vaultId: 1,
+        vaultUuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
       });
       sinon.stub(useCases, 'createItem').resolves(item);
-      const routeOptions = { method: 'POST', path: '/v1/vaults/1/items' };
+      const routeOptions = { method: 'POST', path: '/v1/vaults/50cb9513-6b10-4dce-a64d-d0778d10958d/items' };
 
       // when
       const response = await testServer.inject(routeOptions);
@@ -254,13 +260,13 @@ describe('infrastructure/routes/v1/vaults', () => {
       assert.strictEqual(response.statusCode, 201);
       assert.deepStrictEqual(response.json(), {
         "object": "item",
-        "id": "1",
+        "id": "f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4",
         "username": "item_1",
         "password": "password_1",
         "website": "http://website.1.url",
         "created": now.getTime(),
         "updated": now.getTime(),
-        "vault_id": "1",
+        "vault_id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
       });
     });
   });

--- a/api/test/infrastructure/routes/v1/vaults_test.js
+++ b/api/test/infrastructure/routes/v1/vaults_test.js
@@ -13,7 +13,7 @@ describe('infrastructure/routes/v1/vaults', () => {
 
   beforeEach(() => {
     testServer = getTestServer();
-    testServer.container.register('vaultRepository', { existsByIdAndAccountId: () => true });
+    testServer.container.register('vaultRepository', { existsByUuidAndAccountId: () => true });
   });
 
   afterEach(() => {
@@ -90,7 +90,7 @@ describe('infrastructure/routes/v1/vaults', () => {
     });
   });
 
-  describe('GET /vaults/:id', async () => {
+  describe('GET /vaults/:uuid', async () => {
 
     it('should be ok', async () => {
       // given
@@ -103,8 +103,8 @@ describe('infrastructure/routes/v1/vaults', () => {
         createdAt: now,
         updatedAt: now,
       });
-      sinon.stub(useCases, 'getVault').withArgs({ id: 1, accountId: 1 }).resolves(vault);
-      const routeOptions = { method: 'GET', path: '/v1/vaults/1' };
+      sinon.stub(useCases, 'getVault').withArgs({ vaultUuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4', accountId: 1 }).resolves(vault);
+      const routeOptions = { method: 'GET', path: '/v1/vaults/f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4' };
 
       // when
       const response = await testServer.inject(routeOptions);
@@ -122,7 +122,7 @@ describe('infrastructure/routes/v1/vaults', () => {
     });
   });
 
-  describe('PATCH /vaults/:id', async () => {
+  describe('PATCH /vaults/:uuid', async () => {
 
     it('should be ok', async () => {
       // given
@@ -135,10 +135,10 @@ describe('infrastructure/routes/v1/vaults', () => {
         updatedAt: now,
         accountUuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
       });
-      sinon.stub(useCases, 'updateVault').withArgs({ id: 1, name: 'Edited vault' }).resolves(vault);
+      sinon.stub(useCases, 'updateVault').withArgs({ uuid: '50cb9513-6b10-4dce-a64d-d0778d10958d', name: 'Edited vault' }).resolves(vault);
       const routeOptions = {
         method: 'PATCH',
-        path: '/v1/vaults/1',
+        path: '/v1/vaults/50cb9513-6b10-4dce-a64d-d0778d10958d',
         body: {
           name: 'Edited vault',
         }
@@ -160,7 +160,7 @@ describe('infrastructure/routes/v1/vaults', () => {
     });
   });
 
-  describe('DELETE /vaults/:id', async () => {
+  describe('DELETE /vaults/:uuid', async () => {
 
     it('should be ok', async () => {
       // given
@@ -176,7 +176,7 @@ describe('infrastructure/routes/v1/vaults', () => {
     });
   });
 
-  describe('GET /vaults/:id/items', async () => {
+  describe('GET /vaults/:uuid/items', async () => {
 
     it('should be ok', async () => {
       // given

--- a/api/test/infrastructure/serializers/item-serializer_test.js
+++ b/api/test/infrastructure/serializers/item-serializer_test.js
@@ -26,6 +26,7 @@ describe('infrastructure/serializers/item-serializer', () => {
       const date = new Date('2020-30-12');
       const data = new Item({
         id: 1,
+        uuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4',
         type: ItemType.LOGIN,
         title: 'title',
         username: 'username',
@@ -33,11 +34,11 @@ describe('infrastructure/serializers/item-serializer', () => {
         website: 'http://web.site.url',
         createdAt: date,
         updatedAt: date,
-        vaultId: 1,
+        vaultUuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
       });
       const expected = {
         "object": "item",
-        "id": "1",
+        "id": "f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4",
         "type": "login",
         "title": "title",
         "username": "username",
@@ -45,7 +46,7 @@ describe('infrastructure/serializers/item-serializer', () => {
         "website": "http://web.site.url",
         "created": date.getTime(),
         "updated": date.getTime(),
-        "vault_id": "1",
+        "vault_id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
       };
 
       // when
@@ -63,6 +64,7 @@ describe('infrastructure/serializers/item-serializer', () => {
       const date = new Date('2020-30-12');
       const item1 = new Item({
         id: 1,
+        uuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
         type: ItemType.LOGIN,
         title: 'title_1',
         username: 'username_1',
@@ -70,10 +72,11 @@ describe('infrastructure/serializers/item-serializer', () => {
         website: 'http://1.web.site.url',
         createdAt: date,
         updatedAt: date,
-        vaultId: 1,
+        vaultUuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
       });
       const item2 = new Item({
         id: 2,
+        uuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4',
         type: ItemType.LOGIN,
         title: 'title_2',
         username: 'username_2',
@@ -81,14 +84,14 @@ describe('infrastructure/serializers/item-serializer', () => {
         website: 'http://2.web.site.url',
         createdAt: date,
         updatedAt: date,
-        vaultId: 2,
+        vaultUuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
       });
       const data = [item1, item2];
       const expected = {
         "object": "list",
         "data": [{
           "object": "item",
-          "id": "1",
+          "id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
           "type": "login",
           "title": "title_1",
           "username": "username_1",
@@ -96,10 +99,10 @@ describe('infrastructure/serializers/item-serializer', () => {
           "website": "http://1.web.site.url",
           "created": date.getTime(),
           "updated": date.getTime(),
-          "vault_id": "1",
+          "vault_id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
         }, {
           "object": "item",
-          "id": "2",
+          "id": "f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4",
           "type": "login",
           "title": "title_2",
           "username": "username_2",
@@ -107,7 +110,7 @@ describe('infrastructure/serializers/item-serializer', () => {
           "website": "http://2.web.site.url",
           "created": date.getTime(),
           "updated": date.getTime(),
-          "vault_id": "2",
+          "vault_id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
         }]
       };
 

--- a/api/test/infrastructure/serializers/vault-serializer_test.js
+++ b/api/test/infrastructure/serializers/vault-serializer_test.js
@@ -25,12 +25,13 @@ describe('infrastructure/serializers/vault-serializer', () => {
       // given
       const data = new VaultSummary({
         id: 1,
+        uuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
         name: 'My vault',
         itemsCount: 4,
       });
       const expected = {
         "object": "vault_summary",
-        "id": "1",
+        "id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
         "name": "My vault",
         "items_count": 4,
       };
@@ -50,19 +51,20 @@ describe('infrastructure/serializers/vault-serializer', () => {
       const now = new Date('2020-12-30');
       const data = new Vault({
         id: 1,
+        uuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
         name: 'Default',
         createdAt: now,
         updatedAt: now,
         items: [],
-        accountId: 1,
+        accountUuid: 'f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4',
       });
       const expected = {
         "object": "vault",
-        "id": "1",
+        "id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
         "name": "Default",
         "created": now.getTime(),
         "updated": now.getTime(),
-        "account_id": "1",
+        "account_id": "f1e37124-d1e1-4c5b-9b4e-fbacb2e56db4",
       };
 
       // when
@@ -79,11 +81,13 @@ describe('infrastructure/serializers/vault-serializer', () => {
       // given
       const vaultSummary1 = new VaultSummary({
         id: 1,
+        uuid: '3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13',
         name: 'Default',
         itemsCount: 4,
       });
       const vaultSummary2 = new VaultSummary({
         id: 2,
+        uuid: '50cb9513-6b10-4dce-a64d-d0778d10958d',
         name: 'Shared',
         itemsCount: 0,
       })
@@ -92,12 +96,12 @@ describe('infrastructure/serializers/vault-serializer', () => {
         "object": "list",
         "data": [{
           "object": "vault_summary",
-          "id": "1",
+          "id": "3b923f70-17ed-4ac8-9ee6-5b8ff5a23b13",
           "name": "Default",
           "items_count": 4,
         }, {
           "object": "vault_summary",
-          "id": "2",
+          "id": "50cb9513-6b10-4dce-a64d-d0778d10958d",
           "name": "Shared",
           "items_count": 0,
         }]


### PR DESCRIPTION
Closes #10 

## Problem

The logic behind resource ID is too _guessable_ and _discoverable_. Resources URI are too easy to understand and it is too simple to scrap or bruteforce the URL.

## Solution

Using UUID as resource ID for external needs, meanwhile using technical ID (numbers) for internal purpose.

## Links

- [UUID or GUID as Primary Keys? Be Careful!](https://tomharrisonjr.com/uuid-or-guid-as-primary-keys-be-careful-7b2aa3dcb439)